### PR TITLE
Upgrade Django to v4 and also other libraries

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
-    // "python.pythonPath": "/usr/local/opt/python/bin/python3.6"
-    // "python.pythonPath": "backend/.venv/bin/python3",
-    "python.pythonPath": "/usr/local/bin/python",
-    "files.autoSave": "onFocusChange"
+    "python.defaultInterpreterPath": "${workspaceFolder}/backend/venv/bin/python",
+    "files.autoSave": "onFocusChange",
 }

--- a/backend/blog/models.py
+++ b/backend/blog/models.py
@@ -11,15 +11,16 @@ class Document(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL, # or you can use '[from django.contrib.auth import get_user_model]' then get_user_model(). but only use these in models; you should use account.model.User anywhere else.
         null=True, # you have to use null=True since assigning user is difficult upon creation of this model. assign the author when creating an instance
+        on_delete=models.CASCADE,
     )
-    
+
     title = models.CharField(max_length=100)
     cover_image = models.URLField(max_length=500, default="", blank=True)
     content = models.TextField(
         blank=True,
         # external_plugin_resources=[],
     ) # blank=True : not required column
-    
+
     is_public = models.BooleanField(default=False)
     comment_amount = models.IntegerField(default=0)
 
@@ -30,7 +31,7 @@ class Document(models.Model):
     class Meta:
         abstract = True
         ordering = ['-order', '-pk']
-    
+
     @property
     def preview_content(self):
         return truncatechars(self.content, 100)
@@ -45,6 +46,7 @@ class Comment(models.Model):
 	user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         null=True,
+        on_delete=models.CASCADE,
     )
 	created_at = models.DateTimeField(default=timezone.now)
 
@@ -58,10 +60,10 @@ class CaseStudy(Document):
 
 	class Meta:
 		ordering = ['-order', '-pk']
-	
+
 	def __str__(self):
 		return self.title
-	
+
 
 class HighlightedCaseStudy(models.Model):
     highlighted_abstract = models.TextField(default="", blank=True)
@@ -71,13 +73,13 @@ class HighlightedCaseStudy(models.Model):
     highlighted_image_css_position_mobile = models.CharField(max_length=10, default="", blank=True)
 
     leader_words = models.TextField(default="", blank=True)
-    leader_action = models.CharField(max_length=100)   
-    case_study = models.ForeignKey(CaseStudy)
+    leader_action = models.CharField(max_length=100)
+    case_study = models.ForeignKey(CaseStudy, on_delete=models.CASCADE)
     is_public = models.BooleanField(default=False)
 
     class Meta:
         ordering = ['-case_study__order', '-pk']
-    
+
     # @property
     # def user(self):
     # 	return self.case_study.user

--- a/backend/django_backend/settings.py
+++ b/backend/django_backend/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 
 import os
 
-import datetime
+from datetime import timedelta
 
 try:
     # deployed local
@@ -90,6 +90,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 
     'rest_framework',
+    'rest_framework_simplejwt',
     'corsheaders',
     'storages',
     # 'ckeditor',
@@ -201,15 +202,15 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAdminUser',
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ),
 }
 
-JWT_AUTH = {
-    'JWT_ALLOW_REFRESH': True,
-    'JWT_EXPIRATION_DELTA': datetime.timedelta(minutes=60), # 1 hour
-    # JWT_REFRESH_EXPIRATION_DELTA = datetime.timedelta(days=7), # default is 7 days
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(days=7),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=14),
+    'AUTH_HEADER_TYPES': ('JWT',)
 }
 
 
@@ -228,6 +229,7 @@ USE_TZ = True
 
 
 AUTH_USER_MODEL = 'account.CustomUser'
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 
 # Static files (CSS, JavaScript, Images)
@@ -235,7 +237,7 @@ AUTH_USER_MODEL = 'account.CustomUser'
 
 # Django CORS header settings for frontend
 CORS_ORIGIN_WHITELIST = tuple(filter(bool, [ # filter: https://stackoverflow.com/questions/3845423/remove-empty-strings-from-a-list-of-strings
-        'localhost:4200', # for frontend Angular developement server
+        'http://localhost:4200', # for frontend Angular developement server
     ] + os.environ.get('CORS_DOMAIN_WHITELIST', '').split(',') # frontend hosted on github page
 ))
 

--- a/backend/django_backend/urls.py
+++ b/backend/django_backend/urls.py
@@ -1,30 +1,16 @@
-"""django_backend URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.11/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
-"""
-from django.conf.urls import url, include
+from django.urls import re_path, include
 from django.contrib import admin
 
-from django.contrib.staticfiles.views import serve
-from django.views.generic import RedirectView
 
 from rest_framework import routers
 
 from api import views
 from blog import views as BlogViews
 
-from rest_framework_jwt.views import obtain_jwt_token, refresh_jwt_token
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+)
 
 router = routers.DefaultRouter()
 router.register(r'users', views.UserViewSet)
@@ -34,20 +20,20 @@ router.register(r'case-studies', views.CaseStudyViewSet)
 router.register(r'highlighted-case-studies', views.HighlightedCaseStudyViewSet)
 
 urlpatterns = [
-    url(r'^admin-cool/', include(admin.site.urls)),
-    url(r'^django-health-check/$', BlogViews.HealthCheckView.as_view(), name='django-health-check'),
-    url(r'^fail-test/$', BlogViews.FailView.as_view(), name='fail-test'),
+    re_path(r'^admin-cool/', admin.site.urls),
+    re_path(r'^django-health-check/$', BlogViews.HealthCheckView.as_view(), name='django-health-check'),
+    re_path(r'^fail-test/$', BlogViews.FailView.as_view(), name='fail-test'),
 
-    url(r'^report', BlogViews.EmailView.as_view(), name='report'),
-    url(r'^recaptcha/$', BlogViews.ContactMeView.as_view(), name='recaptcha'),
+    re_path(r'^report', BlogViews.EmailView.as_view(), name='report'),
+    re_path(r'^recaptcha/$', BlogViews.ContactMeView.as_view(), name='recaptcha'),
 
-    # url(r'^ckeditor/', include('ckeditor_uploader.urls')),
-    url(r'^api/uploads/', views.FileUploadView.as_view()),
-    
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')), # for the browsable API login URLs
-    url(r'^api/token-auth/', obtain_jwt_token), # for the browsable API login URLs
-    url(r'^api/token-refresh/', refresh_jwt_token), # for the browsable API login URLs
-    url(r'^api/', include(router.urls)),
+    # re_path(r'^ckeditor/', include('ckeditor_uploader.urls')),
+    re_path(r'^api/uploads/', views.FileUploadView.as_view()),
 
-    url(r'^.*$', views.APIIndexView.as_view()),
+    re_path(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')), # for the browsable API login URLs
+    re_path(r'^api/token-auth/', TokenObtainPairView.as_view(), name='token_obtain_pair'), # for the browsable API login URLs
+    re_path(r'^api/token-refresh/', TokenRefreshView.as_view(), name='token_refresh'), # for the browsable API login URLs
+    re_path(r'^api/', include(router.urls)),
+
+    re_path(r'^.*$', views.APIIndexView.as_view()),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,14 +1,15 @@
 # for django and restful
 #
-django<2
-gunicorn == 19.9.0
-djangorestframework==3.9.1
-django-cors-headers==2.4.0
-djangorestframework-jwt==1.11.0
+django==4.0
+gunicorn==20.1.0
+djangorestframework==3.13.1
+django-cors-headers==3.10.1
+djangorestframework-simplejwt==5.0.0
 
-django-cacheops<=4.3
+django-cacheops==6.0
+django-storages==1.12.3
 
-psycopg2>=2.8,<2.9 # https://stackoverflow.com/a/55418419/9814131
+psycopg2==2.9.3 # https://stackoverflow.com/a/55418419/9814131
 #
 # for local dev, devcontainer in docker is recommended, so OS version does not matter
 #
@@ -21,10 +22,10 @@ psycopg2>=2.8,<2.9 # https://stackoverflow.com/a/55418419/9814131
 
 # for AWS Elastic Beanstalk
 #
-mako==1.0.7
+# mako==1.0.7
 # awsebcli==3.14.6
 
-requests==2.20.0
+requests==2.26.0
 
 # for local dev, devcontainer in docker is recommended, so OS version does not matter
 #
@@ -34,7 +35,6 @@ requests==2.20.0
 # pillow==5.3.0
 
 # django-ckeditor==5.6.1
-boto3==1.9.27
-django-storages==1.7.1
+boto3==1.20.26
+awscli==1.22.26
 
-awscli

--- a/cicd/microservice.tf
+++ b/cicd/microservice.tf
@@ -23,7 +23,7 @@ module "iriversland2_api" {
   app_label               = "iriversland2-api"
   app_exposed_port        = 8000
   app_deployed_domain     = "api.shaungc.com"
-  cors_domain_whitelist   = ["shaungc.com"]
+  cors_domain_whitelist   = ["https://shaungc.com"]
   app_container_image     = "shaungc/iriversland2-django"
   app_container_image_tag = var.app_container_image_tag
   app_secret_name_list = [


### PR DESCRIPTION
First draft of upgrade to Django v4.

Status
- [x] Backend make changes
- [x] Backend can spin up server
- [x] Backend can talk to frontend
    - [x] Frontend prep dev environment
        - Encounter error, using node 17 or 16 got error, `npm I` failed. Solved by [changing `node-sass` to `sass`](https://stackoverflow.com/questions/58623072/npm-node-sass-installation-fails), as the former is deprecated.
        - Some error in `sass`. Solved by [this SO](https://stackoverflow.com/a/63561694/9814131).
    - [x] Frontend make changes to accept backend payload change
    - [x] Frontend can login OK
    - [x] Frontend can fetch user objects OK

Migration plan:

```
❯ ./manage.py migrate --plan                                                                                                       
Planned operations:
admin.0003_logentry_add_action_flag_choices
    Alter field action_flag on logentry
auth.0009_alter_user_last_name_max_length
    Alter field last_name on user
auth.0010_alter_group_name_max_length
    Alter field name on group
auth.0011_update_proxy_permissions
    Raw Python operation ->     Update the content_type of prox…
auth.0012_alter_user_first_name_max_length
    Alter field first_name on user
```